### PR TITLE
feat: Create basic URL parameter browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-# bing-params
+# URL Parameter Adder Extension
+
+This browser extension allows users to select predefined URL parameters and add them to the current page's URL, then reloads the page.
+
+## Features
+
+*   Select from a list of parameters:
+    *   `features=acftokall,finacfmgux`
+    *   `mobile=1`
+    *   `setapplicationendpoint=BNZEEAP00033FAD`
+    *   `testhooks=1`
+*   Reloads the page with the selected parameters.
+*   Works on `http` and `https` pages.
+
+## How to Test (Locally)
+
+To test this extension locally, follow these steps for your browser:
+
+### Google Chrome / Microsoft Edge (Chromium-based)
+
+1.  Open your browser and navigate to `chrome://extensions` (for Chrome) or `edge://extensions` (for Edge).
+2.  Enable **Developer mode**. This is usually a toggle switch on the top right of the page.
+3.  Click on the **"Load unpacked"** button.
+4.  In the file dialog that appears, navigate to the directory where you have the extension files (the directory containing `manifest.json`) and select this directory.
+5.  The extension should now be loaded and visible in your extensions list. You can click its icon (which will be a placeholder) in the browser toolbar to open the popup.
+
+### Mozilla Firefox
+
+1.  Open Firefox and navigate to `about:debugging#/runtime/this-firefox`.
+2.  Click on **"Load Temporary Add-on..."**.
+3.  In the file dialog, navigate to the directory containing the extension files and select the `manifest.json` file (or any file in the root of the extension directory).
+4.  The extension should now be loaded temporarily. You can click its icon in the browser toolbar.
+
+### Testing Steps
+
+1.  Navigate to any website (e.g., `https://www.example.com`).
+2.  Click the extension's icon in the browser toolbar.
+3.  The popup should appear with the list of parameters.
+4.  Select one or more parameters using the checkboxes.
+5.  Click the "Add Parameters and Reload" button.
+6.  The page should reload, and the URL in the address bar should now include the parameters you selected. For example, if you selected `mobile=1` on `https://www.example.com`, the new URL should be `https://www.example.com/?mobile=1`.
+7.  Test adding parameters to URLs that already have parameters.
+8.  Test on different websites.
+9.  Test deselecting all parameters (should show an alert).
+10. Test on non-http/https pages (e.g., `about:blank` or a local file `file:///...`) to see the alert message.
+
+
+## Preparing for Publishing
+
+Before publishing to extension stores, you'll need to:
+
+1.  **Replace Placeholder Icons:** The current icons in the `icons/` directory (`icon16.png`, `icon48.png`, `icon128.png`) are placeholder text files. You should replace these with actual PNG image files of the specified dimensions.
+2.  **Thoroughly Test:** Test all features across Chrome, Firefox, and Edge as per the "Testing Steps" above.
+3.  **Review Store-Specific Guidelines:**
+    *   [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
+    *   [Microsoft Edge Add-ons Developer Portal](https://partner.microsoft.com/en-us/dashboard/microsoftedge/)
+    *   [Firefox Add-on Developer Hub](https://addons.mozilla.org/en-US/developers/)
+    Each store has its own policies regarding manifest fields, permissions, UI, security, and content. Ensure your extension complies with all of them.
+4.  **Create Store Listing Assets:** This typically includes:
+    *   A compelling and clear extension name and description.
+    *   Screenshots of your extension in action.
+    *   Promotional images or videos (if applicable).
+    *   A privacy policy (if your extension handles user data, though this one primarily manipulates URLs locally).
+5.  **Package Your Extension:**
+    *   For Chrome Web Store and Microsoft Edge Add-ons, you typically create a ZIP file containing all your extension files (`manifest.json`, `popup.html`, `popup.js`, `style.css`, and the `icons/` directory).
+    *   Firefox also uses a ZIP file, often with a `.xpi` extension, but the packaging process is similar.
+
+Refer to the documentation provided by each browser's extension store for the most up-to-date and detailed instructions.

--- a/icons/icon128.png
+++ b/icons/icon128.png
@@ -1,0 +1,1 @@
+placeholder icon 128x128

--- a/icons/icon16.png
+++ b/icons/icon16.png
@@ -1,0 +1,1 @@
+placeholder icon 16x16

--- a/icons/icon48.png
+++ b/icons/icon48.png
@@ -1,0 +1,1 @@
+placeholder icon 48x48

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 3,
+  "name": "URL Parameter Adder",
+  "version": "1.0",
+  "description": "Adds selected parameters to the current URL and reloads the page.",
+  "permissions": [
+    "activeTab",
+    "scripting"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  }
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>URL Parameter Adder</title>
+  <link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+  <h1>Select Parameters</h1>
+  <form id="paramsForm">
+    <div>
+      <input type="checkbox" id="features" name="features" value="features=acftokall,finacfmgux">
+      <label for="features">features=acftokall,finacfmgux</label>
+    </div>
+    <div>
+      <input type="checkbox" id="mobile" name="mobile" value="mobile=1">
+      <label for="mobile">mobile=1</label>
+    </div>
+    <div>
+      <input type="checkbox" id="setapplicationendpoint" name="setapplicationendpoint" value="setapplicationendpoint=BNZEEAP00033FAD">
+      <label for="setapplicationendpoint">setapplicationendpoint=BNZEEAP00033FAD</label>
+    </div>
+    <div>
+      <input type="checkbox" id="testhooks" name="testhooks" value="testhooks=1">
+      <label for="testhooks">testhooks=1</label>
+    </div>
+    <button type="submit">Add Parameters and Reload</button>
+  </form>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const paramsForm = document.getElementById('paramsForm');
+
+  paramsForm.addEventListener('submit', function (event) {
+    event.preventDefault(); // Prevent default form submission
+
+    const selectedParams = [];
+    const checkboxes = paramsForm.querySelectorAll('input[type="checkbox"]:checked');
+
+    checkboxes.forEach(function (checkbox) {
+      selectedParams.push(checkbox.value); // value is "name=value"
+    });
+
+    if (selectedParams.length > 0) {
+      chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
+        const currentTab = tabs[0];
+        if (currentTab && currentTab.id) {
+          // Check if the tab has a valid URL before attempting to inject script
+          if (currentTab.url && (currentTab.url.startsWith('http://') || currentTab.url.startsWith('https://'))) {
+            chrome.scripting.executeScript({
+              target: { tabId: currentTab.id },
+              function: addParametersToUrlAndReload,
+              args: [selectedParams]
+            });
+          } else {
+            alert('Cannot add parameters to the current page. This extension only works on http or https pages.');
+            // Optionally, you could disable the form or button if not on a valid page.
+          }
+        } else {
+          console.error("Could not get current tab information.");
+          alert("Error: Could not get current tab information.");
+        }
+      });
+    } else {
+      alert('Please select at least one parameter.');
+    }
+  });
+});
+
+function addParametersToUrlAndReload(paramsArray) {
+  try {
+    const url = new URL(window.location.href);
+    paramsArray.forEach(paramString => {
+      const parts = paramString.split('=');
+      if (parts.length === 2) {
+        url.searchParams.set(parts[0], parts[1]);
+      }
+    });
+    window.location.href = url.toString();
+  } catch (e) {
+    // Alert if the current page is not a valid URL (e.g., about:blank) or any other error.
+    alert(`Error modifying URL: ${e.message}. Please ensure you are on a valid http/https page.`);
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,45 @@
+body {
+  font-family: sans-serif;
+  margin: 10px;
+  width: 350px; /* Increased width slightly for longer labels */
+}
+
+h1 {
+  font-size: 1.2em;
+  text-align: center;
+  margin-bottom: 15px;
+}
+
+#paramsForm div {
+  margin-bottom: 8px; /* Spacing between checkbox lines */
+  display: flex; /* Align checkbox and label nicely */
+  align-items: center;
+}
+
+#paramsForm input[type="checkbox"] {
+  margin-right: 8px; /* Space between checkbox and its label */
+}
+
+#paramsForm label {
+  font-size: 0.9em;
+  /* Allow label to take remaining space and wrap if necessary */
+  flex-grow: 1;
+  word-break: break-all; /* Break long parameter strings if needed */
+}
+
+button[type="submit"] { /* More specific selector for the submit button */
+  background-color: #4CAF50;
+  color: white;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  display: block;
+  width: 100%;
+  font-size: 0.9em;
+  margin-top: 20px; /* Increased top margin for separation */
+}
+
+button[type="submit"]:hover {
+  background-color: #45a049;
+}


### PR DESCRIPTION
This commit introduces a browser extension that allows you to add predefined parameters to the current URL and reload the page.

Key features:
- manifest.json: Defines the extension for Manifest V3.
- popup.html: Provides a UI with checkboxes for parameter selection.
  - Parameters:
    - features=acftokall,finacfmgux
    - mobile=1
    - setapplicationendpoint=BNZEEAP00033FAD
    - testhooks=1
- popup.js: Handles logic for capturing your selections and uses chrome.scripting.executeScript to modify the active tab's URL.
- icons: Includes placeholder icons.
- README.md: Contains detailed instructions for local testing across Chrome, Firefox, and Edge, as well as guidance for preparing the extension for store publishing.

The extension is designed for cross-browser compatibility.